### PR TITLE
remove mentions of nuget package and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,54 @@ The PayPal Server SDK provides integration access to the PayPal REST APIs. The A
 
 Find out more here: [https://developer.paypal.com/docs/api/orders/v2/](https://developer.paypal.com/docs/api/orders/v2/)
 
+## Building
+
+The generated code uses the Newtonsoft Json.NET NuGet Package. If the automatic NuGet package restore is enabled, these dependencies will be installed automatically. Therefore, you will need internet access for build.
+
+* Open the solution (PaypalServerSdk.sln) file.
+
+Invoke the build process using Ctrl + Shift + B shortcut key or using the Build menu as shown below.
+
+The build process generates a portable class library, which can be used like a normal class library. More information on how to use can be found at the MSDN Portable Class Libraries documentation.
+
+The supported version is **.NET Standard 2.0**. For checking compatibility of your .NET implementation with the generated library, [click here](https://dotnet.microsoft.com/en-us/platform/dotnet-standard#versions).
+
+## Installation
+
+The following section explains how to use the PaypalServerSdk.Standard library in a new project.
+
+### 1. Starting a new project
+
+For starting a new project, right click on the current solution from the solution explorer and choose `Add -> New Project`.
+
+![Add a new project in Visual Studio](https://apidocs.io/illustration/cs?workspaceFolder=PayPal%20Server%20SDK-CSharp&workspaceName=PaypalServerSdk&projectName=PaypalServerSdk.Standard&rootNamespace=PaypalServerSdk.Standard&step=addProject)
+
+Next, choose `Console Application`, provide `TestConsoleProject` as the project name and click OK.
+
+![Create a new Console Application in Visual Studio](https://apidocs.io/illustration/cs?workspaceFolder=PayPal%20Server%20SDK-CSharp&workspaceName=PaypalServerSdk&projectName=PaypalServerSdk.Standard&rootNamespace=PaypalServerSdk.Standard&step=createProject)
+
+### 2. Set as startup project
+
+The new console project is the entry point for the eventual execution. This requires us to set the `TestConsoleProject` as the start-up project. To do this, right-click on the `TestConsoleProject` and choose `Set as StartUp Project` form the context menu.
+
+![Adding a project reference](https://apidocs.io/illustration/cs?workspaceFolder=PayPal%20Server%20SDK-CSharp&workspaceName=PaypalServerSdk&projectName=PaypalServerSdk.Standard&rootNamespace=PaypalServerSdk.Standard&step=setStartup)
+
+### 3. Add reference of the library project
+
+In order to use the `PaypalServerSdk.Standard` library in the new project, first we must add a project reference to the `TestConsoleProject`. First, right click on the `References` node in the solution explorer and click `Add Reference...`
+
+![Adding a project reference](https://apidocs.io/illustration/cs?workspaceFolder=PayPal%20Server%20SDK-CSharp&workspaceName=PaypalServerSdk&projectName=PaypalServerSdk.Standard&rootNamespace=PaypalServerSdk.Standard&step=addReference)
+
+Next, a window will be displayed where we must set the `checkbox` on `PaypalServerSdk.Standard` and click `OK`. By doing this, we have added a reference of the `PaypalServerSdk.Standard` project into the new `TestConsoleProject`.
+
+![Creating a project reference](https://apidocs.io/illustration/cs?workspaceFolder=PayPal%20Server%20SDK-CSharp&workspaceName=PaypalServerSdk&projectName=PaypalServerSdk.Standard&rootNamespace=PaypalServerSdk.Standard&step=createReference)
+
+### 4. Write sample code
+
+Once the `TestConsoleProject` is created, a file named `Program.cs` will be visible in the solution explorer with an empty `Main` method. This is the entry point for the execution of the entire solution. Here, you can add code to initialize the client library and acquire the instance of a Controller class. Sample code to initialize the client library and using Controller methods is given in the subsequent sections.
+
+![Adding a project reference](https://apidocs.io/illustration/cs?workspaceFolder=PayPal%20Server%20SDK-CSharp&workspaceName=PaypalServerSdk&projectName=PaypalServerSdk.Standard&rootNamespace=PaypalServerSdk.Standard&step=addCode)
+
 ## Initialize the API Client
 
 **_Note:_** Documentation for the client can be found [here.](https://www.github.com/paypal/PayPal-Dotnet-Server-SDK/tree/0.5.2/doc/client.md)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Find out more here: [https://developer.paypal.com/docs/api/orders/v2/](https://d
 
 The generated code uses the Newtonsoft Json.NET NuGet Package. If the automatic NuGet package restore is enabled, these dependencies will be installed automatically. Therefore, you will need internet access for build.
 
-* Open the solution (PaypalServerSdk.sln) file.
+* Open the solution (PaypalServerSDK.sln) file.
 
 Invoke the build process using Ctrl + Shift + B shortcut key or using the Build menu as shown below.
 
@@ -42,33 +42,33 @@ The following section explains how to use the PaypalServerSdk.Standard library i
 
 For starting a new project, right click on the current solution from the solution explorer and choose `Add -> New Project`.
 
-![Add a new project in Visual Studio](https://apidocs.io/illustration/cs?workspaceFolder=PayPal%20Server%20SDK-CSharp&workspaceName=PaypalServerSdk&projectName=PaypalServerSdk.Standard&rootNamespace=PaypalServerSdk.Standard&step=addProject)
+![Add a new project in Visual Studio](https://apidocs.io/illustration/cs?workspaceFolder=PayPal%20Server%20SDK-CSharp&workspaceName=PaypalServerSDK&projectName=PaypalServerSdk.Standard&rootNamespace=PaypalServerSdk.Standard&step=addProject)
 
 Next, choose `Console Application`, provide `TestConsoleProject` as the project name and click OK.
 
-![Create a new Console Application in Visual Studio](https://apidocs.io/illustration/cs?workspaceFolder=PayPal%20Server%20SDK-CSharp&workspaceName=PaypalServerSdk&projectName=PaypalServerSdk.Standard&rootNamespace=PaypalServerSdk.Standard&step=createProject)
+![Create a new Console Application in Visual Studio](https://apidocs.io/illustration/cs?workspaceFolder=PayPal%20Server%20SDK-CSharp&workspaceName=PaypalServerSDK&projectName=PaypalServerSdk.Standard&rootNamespace=PaypalServerSdk.Standard&step=createProject)
 
 ### 2. Set as startup project
 
 The new console project is the entry point for the eventual execution. This requires us to set the `TestConsoleProject` as the start-up project. To do this, right-click on the `TestConsoleProject` and choose `Set as StartUp Project` form the context menu.
 
-![Adding a project reference](https://apidocs.io/illustration/cs?workspaceFolder=PayPal%20Server%20SDK-CSharp&workspaceName=PaypalServerSdk&projectName=PaypalServerSdk.Standard&rootNamespace=PaypalServerSdk.Standard&step=setStartup)
+![Adding a project reference](https://apidocs.io/illustration/cs?workspaceFolder=PayPal%20Server%20SDK-CSharp&workspaceName=PaypalServerSDK&projectName=PaypalServerSdk.Standard&rootNamespace=PaypalServerSdk.Standard&step=setStartup)
 
 ### 3. Add reference of the library project
 
 In order to use the `PaypalServerSdk.Standard` library in the new project, first we must add a project reference to the `TestConsoleProject`. First, right click on the `References` node in the solution explorer and click `Add Reference...`
 
-![Adding a project reference](https://apidocs.io/illustration/cs?workspaceFolder=PayPal%20Server%20SDK-CSharp&workspaceName=PaypalServerSdk&projectName=PaypalServerSdk.Standard&rootNamespace=PaypalServerSdk.Standard&step=addReference)
+![Adding a project reference](https://apidocs.io/illustration/cs?workspaceFolder=PayPal%20Server%20SDK-CSharp&workspaceName=PaypalServerSDK&projectName=PaypalServerSdk.Standard&rootNamespace=PaypalServerSdk.Standard&step=addReference)
 
 Next, a window will be displayed where we must set the `checkbox` on `PaypalServerSdk.Standard` and click `OK`. By doing this, we have added a reference of the `PaypalServerSdk.Standard` project into the new `TestConsoleProject`.
 
-![Creating a project reference](https://apidocs.io/illustration/cs?workspaceFolder=PayPal%20Server%20SDK-CSharp&workspaceName=PaypalServerSdk&projectName=PaypalServerSdk.Standard&rootNamespace=PaypalServerSdk.Standard&step=createReference)
+![Creating a project reference](https://apidocs.io/illustration/cs?workspaceFolder=PayPal%20Server%20SDK-CSharp&workspaceName=PaypalServerSDK&projectName=PaypalServerSdk.Standard&rootNamespace=PaypalServerSdk.Standard&step=createReference)
 
 ### 4. Write sample code
 
 Once the `TestConsoleProject` is created, a file named `Program.cs` will be visible in the solution explorer with an empty `Main` method. This is the entry point for the execution of the entire solution. Here, you can add code to initialize the client library and acquire the instance of a Controller class. Sample code to initialize the client library and using Controller methods is given in the subsequent sections.
 
-![Adding a project reference](https://apidocs.io/illustration/cs?workspaceFolder=PayPal%20Server%20SDK-CSharp&workspaceName=PaypalServerSdk&projectName=PaypalServerSdk.Standard&rootNamespace=PaypalServerSdk.Standard&step=addCode)
+![Adding a project reference](https://apidocs.io/illustration/cs?workspaceFolder=PayPal%20Server%20SDK-CSharp&workspaceName=PaypalServerSDK&projectName=PaypalServerSdk.Standard&rootNamespace=PaypalServerSdk.Standard&step=addCode)
 
 ## Initialize the API Client
 

--- a/README.md
+++ b/README.md
@@ -22,17 +22,6 @@ The PayPal Server SDK provides integration access to the PayPal REST APIs. The A
 
 Find out more here: [https://developer.paypal.com/docs/api/orders/v2/](https://developer.paypal.com/docs/api/orders/v2/)
 
-## Install the Package
-
-If you are building with .NET CLI tools then you can also use the following command:
-
-```bash
-dotnet add package PayPalServerSDK --version 0.5.2
-```
-
-You can also view the package at:
-https://www.nuget.org/packages/PayPalServerSDK/0.5.2
-
 ## Initialize the API Client
 
 **_Note:_** Documentation for the client can be found [here.](https://www.github.com/paypal/PayPal-Dotnet-Server-SDK/tree/0.5.2/doc/client.md)


### PR DESCRIPTION
Since the nuget package isn't yet live this PR removes the nuget install instructions and link for it in the README and swaps in the manual install instructions. 